### PR TITLE
Update fmDataAPI.class.php

### DIFF
--- a/fmPDA/v2/fmDataAPI.class.php
+++ b/fmPDA/v2/fmDataAPI.class.php
@@ -1198,7 +1198,7 @@ class fmDataAPI extends fmAPI
       if (array_key_exists('sort', $params) && (count($params['sort']) > 0)) {
          $sort = array();
          foreach ($params['sort'] as $sortItem) {
-            $sort[] = array('fieldName' => rawurlencode($sortItem['fieldName']),
+            $sort[] = array('fieldName' => ($key == 'get') ? $sortItem['fieldName'] : rawurlencode($sortItem['fieldName']),
                             'sortOrder' => array_key_exists('sortOrder', $sortItem) ? $sortItem['sortOrder'] : 'ascend');
          }
          $data[$keys[$key]['sort']] = ($key == 'get') ? rawurlencode(json_encode($sort)) : $sort;


### PR DESCRIPTION
When adding a sort field that contains a space, there are two consecutive `rawurlencode`s causing the % in the `%20` to be encoded, resulting in `%2520` and breaking the query (the API returns `Field is missing`). This patch prevents the double encode when using a GET request.